### PR TITLE
Add `--quiet` flag, use `stderr` for error messages, prefix messages with `[catflap]`

### DIFF
--- a/integrations/hyper/src/main.rs
+++ b/integrations/hyper/src/main.rs
@@ -17,12 +17,12 @@ fn main() {
             // At this point, you should attempt to bind to an IP:Port as
             // normal, so the server can still start if not used with
             // Catflap. For this example, we omit that and simply quit.
-            println!("Could not bind to FD!");
+            eprintln!("Could not bind to FD!");
             exit(1);
         })
         .handle(|_: Request, _: Response| {}) // Answer 200 OK to every request
         .unwrap_or_else(|e| {
-            println!("Could not start server! {}", e);
+            eprintln!("Could not start server! {}", e);
             exit(1);
         });
 }

--- a/integrations/iron/src/main.rs
+++ b/integrations/iron/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
             // At this point, you should attempt to bind to an IP:Port as
             // normal, so the server can still start if not used with
             // Catflap. For this example, we omit that and simply quit.
-            println!("Could not bind to FD!");
+            eprintln!("Could not bind to FD!");
             exit(1);
         });
 
@@ -30,5 +30,5 @@ fn main() {
         .listen(listener, Protocol::http())
         .unwrap();
 
-    println!("Listening");
+    eprintln!("Listening");
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -22,6 +22,10 @@ pub fn parse() -> ArgMatches<'static> {
              .long("port")
              .default_value("5000"))
 
+        .arg(Arg::with_name("quiet")
+             .short("q")
+             .long("quiet"))
+
         .arg(Arg::with_name("command")
              .multiple(true)
              .required(true))

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,17 +18,17 @@ fn main() {
         args.value_of("host").unwrap(),
         args.value_of("port").unwrap()
     )).unwrap_or_else(|e| {
-        eprintln!("Bad address: {}", e);
+        eprintln!("[catflap] Bad address: {}", e);
         exit(1);
     });
 
 	let fd = sock::on(addr).unwrap_or_else(|e| {
-        eprintln!("Could not bind: {}", e);
+        eprintln!("[catflap] Could not bind: {}", e);
         exit(1);
     });
 
 	let at = sock::at(fd).unwrap_or_else(|e| {
-        eprintln!("Could not get address: {}", e);
+        eprintln!("[catflap] Could not get address: {}", e);
         exit(1);
     });
 
@@ -37,7 +37,7 @@ fn main() {
     let quiet = args.is_present("quiet");
 
     if !quiet {
-        eprintln!("[Catflap listening at {}]", at);
+        eprintln!("[catflap] Listening at: {}", at);
     }
 
     let mut cmd_args = args.values_of("command")
@@ -51,5 +51,5 @@ fn main() {
         .env(env, format!("{}", fd))
         .exec();
 
-    eprintln!("Error running command: {}", err);
+    eprintln!("[catflap] Error running command: {}", err);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,17 +18,17 @@ fn main() {
         args.value_of("host").unwrap(),
         args.value_of("port").unwrap()
     )).unwrap_or_else(|e| {
-        println!("Bad address: {}", e);
+        eprintln!("Bad address: {}", e);
         exit(1);
     });
 
 	let fd = sock::on(addr).unwrap_or_else(|e| {
-        println!("Could not bind: {}", e);
+        eprintln!("Could not bind: {}", e);
         exit(1);
     });
 
 	let at = sock::at(fd).unwrap_or_else(|e| {
-        println!("Could not get address: {}", e);
+        eprintln!("Could not get address: {}", e);
         exit(1);
     });
 
@@ -37,7 +37,7 @@ fn main() {
     let quiet = args.is_present("quiet");
 
     if !quiet {
-        println!("[Catflap listening at {}]", at);
+        eprintln!("[Catflap listening at {}]", at);
     }
 
     let mut cmd_args = args.values_of("command")
@@ -51,5 +51,5 @@ fn main() {
         .env(env, format!("{}", fd))
         .exec();
 
-    println!("Error running command: {}", err);
+    eprintln!("Error running command: {}", err);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,11 @@ fn main() {
 
     let env = args.value_of("env").unwrap();
 
-	println!("[Catflap listening at {}]", at);
+    let quiet = args.is_present("quiet");
+
+    if !quiet {
+        println!("[Catflap listening at {}]", at);
+    }
 
     let mut cmd_args = args.values_of("command")
         .unwrap()


### PR DESCRIPTION
[These patches are for the `main` branch, i.e. `v1`;  if you intend to release soon `v2`, I could port them to `v2` also.]

The following three individual patches do the following:
* add `--quiet` (or `-q`) flag, as per #4;
* uses `stderr` (as opposed to `stdout`) for messages, by replacing `println!` with `eprintln!`;  (it is useful when the output of the server is piped for analysis;)
* prefix messages with `[catflap]` to make it more clear which tool generated the error;  (given that `catflap` is used to launch another tool that might have its own messages;)

If the last patch (adding `[catflap]` prefix) isn't OK, I'll drop it from the pull request.
