### PR TITLE
Enable by default `SO_REUSEADDR` (or equivalent) socket option

### DIFF
--- a/src/sock.rs
+++ b/src/sock.rs
@@ -7,7 +7,9 @@ use nix::sys::socket::{
     getsockname,
     InetAddr,
     listen,
+    setsockopt,
     socket,
+    sockopt,
     SockAddr,
     SockFlag,
     SockType,
@@ -25,6 +27,7 @@ pub fn on(addr: SocketAddr) -> Result<RawFd> {
 	));
 
     let result = Ok(())
+		.and_then(|_| setsockopt(sock, sockopt::ReuseAddr, &true))
 		.and_then(|_| bind(sock, &SockAddr::new_inet(
 			InetAddr::from_std(&addr))
 		))


### PR DESCRIPTION
As proposed in #5 I've made a simple patch against the current `main` branch to add this option to the listening socket.  (The option must be set before both `bind` and `listen`.)

Apparently the `nix` crate has support for the generic `ReuseAddr` option, and it also appear to be present in the POSIX specification, thus I think it should be compatible with all UNIX-like systems.
